### PR TITLE
Fixes: leaking Jobs and broken git prompt

### DIFF
--- a/pure-pwsh/async.ps1
+++ b/pure-pwsh/async.ps1
@@ -1,3 +1,5 @@
+$Script:UpdateJob = $null
+
 function UpdateStatus() {
   $pure._state.repoDir = GetRepoDir
 
@@ -5,7 +7,7 @@ function UpdateStatus() {
     $pure._state.isPending = $true
     &$pure._functions.log "Scheduling OnIdle event"
 
-    $null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action $OnIdleCallback
+    $Script:UpdateJob = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action $Script:OnIdleCallback
   }
 }
 
@@ -22,6 +24,7 @@ $Script:OnIdleCallback = {
     $isTest ? (&prompt) : [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
   }
   $pure._state.isPending = $false
+  Remove-Job $Script:UpdateJob
 }
 
 $Script:UpdateOnChange = {

--- a/pure-pwsh/git.ps1
+++ b/pure-pwsh/git.ps1
@@ -2,8 +2,8 @@ $Script:emptyStatus = [Ordered] @{
   ahead   = $false
   behind  = $false
   dirty   = $false
-  branch  = $null
-  repoDir = $null
+  branch  = ""
+  repoDir = ""
 }
 
 function GetRepoDir() {

--- a/pure-pwsh/pure-pwsh.psd1
+++ b/pure-pwsh/pure-pwsh.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'pure-pwsh.psm1'
-  ModuleVersion     = '0.8.0'
+  ModuleVersion     = '0.8.1'
   GUID              = '94d168c3-c48f-4937-bc82-4d54b5b9e777'
 
   Author            = 'Nick Cox'


### PR DESCRIPTION
I have been using this for my prompt as it is is quite small and is still in pure PowerShell/.Net. I noticed that the Git status part of the prompt wasn't working, so I looked into it a bit and found that the call to `Compare-Object` was silently failing when it tried comparing the `$null`s from the `$emptyStatus` hash. I swapped the nulls for empty strings and it seems to be working fine now.

While investigating, I also noticed that `Get-Job` showed many many dead jobs in one of my longer-running shells. Turns out each `Register-EngineEvent` spins up a new job and they will stick around even if they only needed to live for one event. I stop the leak by keeping track of the last update job and calling `Remove-Job` on it at the end of it's handler. That seems to just work.